### PR TITLE
Fix the bug that HAL_NAND_Read_Page_8b and HAL_NAND_Read_SpareArea_8b cannot read data normally.

### DIFF
--- a/Src/stm32f7xx_hal_nand.c
+++ b/Src/stm32f7xx_hal_nand.c
@@ -635,7 +635,7 @@ HAL_StatusTypeDef HAL_NAND_Read_Page_8b(NAND_HandleTypeDef *hnand, NAND_AddressT
       /* Get Data into Buffer */
       for (index = 0U; index < hnand->Config.PageSize; index++)
       {
-        *buff = *(uint8_t *)deviceaddress;
+        *buff = *(__IO uint8_t *)deviceaddress;
         buff++;
       }
 
@@ -1285,7 +1285,7 @@ HAL_StatusTypeDef HAL_NAND_Read_SpareArea_8b(NAND_HandleTypeDef *hnand, NAND_Add
       /* Get Data into Buffer */
       for (index = 0U; index < hnand->Config.SpareAreaSize; index++)
       {
-        *buff = *(uint8_t *)deviceaddress;
+        *buff = *(__IO uint8_t *)deviceaddress;
         buff++;
       }
 

--- a/Src/stm32f7xx_hal_nand.c
+++ b/Src/stm32f7xx_hal_nand.c
@@ -803,7 +803,7 @@ HAL_StatusTypeDef HAL_NAND_Read_Page_16b(NAND_HandleTypeDef *hnand, NAND_Address
       /* Get Data into Buffer */
       for (index = 0U; index < hnand->Config.PageSize; index++)
       {
-        *buff = *(uint16_t *)deviceaddress;
+        *buff = *(__IO uint16_t *)deviceaddress;
         buff++;
       }
 
@@ -1450,7 +1450,7 @@ HAL_StatusTypeDef HAL_NAND_Read_SpareArea_16b(NAND_HandleTypeDef *hnand, NAND_Ad
       /* Get Data into Buffer */
       for (index = 0U; index < hnand->Config.SpareAreaSize; index++)
       {
-        *buff = *(uint16_t *)deviceaddress;
+        *buff = *(__IO uint16_t *)deviceaddress;
         buff++;
       }
 


### PR DESCRIPTION
This PR fixed the issue #6 .

By changing the `*buff = *(uint8_t *)deviceaddress;` to `*buff = *(__IO uint8_t *)deviceaddress;` , now the data could be read correctly.

Additionally, I have signed the CLA as required by CONTRIBUTING.md.