### PR TITLE
[LL][ADC]: fix rank calculation in LL_ADC_INJ_SetSequencerRanks

### DIFF
--- a/Inc/stm32f7xx_ll_adc.h
+++ b/Inc/stm32f7xx_ll_adc.h
@@ -2969,11 +2969,13 @@ __STATIC_INLINE void LL_ADC_INJ_SetSequencerRanks(ADC_TypeDef *ADCx, uint32_t Ra
   /* in register depending on parameter "Rank".                               */
   /* Parameters "Rank" and "Channel" are used with masks because containing   */
   /* other bits reserved for other purpose.                                   */
-  uint32_t tmpreg1 = (READ_BIT(ADCx->JSQR, ADC_JSQR_JL) >> ADC_JSQR_JL_Pos) + 1U;
+  uint8_t jsqoffset =
+    __ADC_MASK_SHIFT(Rank, ADC_INJ_RANK_ID_JSQR_MASK) + 3U -
+    ((READ_BIT(ADCx->JSQR, ADC_JSQR_JL) >> ADC_JSQR_JL_Pos) + 1U);
   
   MODIFY_REG(ADCx->JSQR,
-             ADC_CHANNEL_ID_NUMBER_MASK << (5U * (uint8_t)(((Rank) + 3U) - (tmpreg1))),
-             (Channel & ADC_CHANNEL_ID_NUMBER_MASK) << (5U * (uint8_t)(((Rank) + 3U) - (tmpreg1))));
+             ADC_CHANNEL_ID_NUMBER_MASK << (5U * jsqoffset),
+             (Channel & ADC_CHANNEL_ID_NUMBER_MASK) << (5U * jsqoffset));
 }
 
 /**
@@ -3034,12 +3036,12 @@ __STATIC_INLINE void LL_ADC_INJ_SetSequencerRanks(ADC_TypeDef *ADCx, uint32_t Ra
   */
 __STATIC_INLINE uint32_t LL_ADC_INJ_GetSequencerRanks(ADC_TypeDef *ADCx, uint32_t Rank)
 {
-  uint32_t tmpreg1 = (READ_BIT(ADCx->JSQR, ADC_JSQR_JL) >> ADC_JSQR_JL_Pos)  + 1U;
+  uint8_t jsqoffset =
+    __ADC_MASK_SHIFT(Rank, ADC_INJ_RANK_ID_JSQR_MASK) + 3U -
+    ((READ_BIT(ADCx->JSQR, ADC_JSQR_JL) >> ADC_JSQR_JL_Pos) + 1U);
   
   return (uint32_t)(READ_BIT(ADCx->JSQR,
-                             ADC_CHANNEL_ID_NUMBER_MASK << (5U * (uint8_t)(((Rank) + 3U) - (tmpreg1))))
-                    >> (5U * (uint8_t)(((Rank) + 3U) - (tmpreg1)))
-                   );
+                             ADC_CHANNEL_ID_NUMBER_MASK << (5U * jsqoffset)) >> (5U * jsqoffset));
 }
 
 /**

--- a/Inc/stm32f7xx_ll_adc.h
+++ b/Inc/stm32f7xx_ll_adc.h
@@ -2923,6 +2923,8 @@ __STATIC_INLINE uint32_t LL_ADC_INJ_GetSequencerDiscont(ADC_TypeDef *ADCx)
   *         TempSensor, ...), measurement paths to internal channels must be
   *         enabled separately.
   *         This can be done using function @ref LL_ADC_SetCommonPathInternalCh().
+  * @note   Call @ref LL_ADC_INJ_SetSequencerLength to set the sequencer length
+  *         before using this function.
   * @rmtoll JSQR     JSQ1           LL_ADC_INJ_SetSequencerRanks\n
   *         JSQR     JSQ2           LL_ADC_INJ_SetSequencerRanks\n
   *         JSQR     JSQ3           LL_ADC_INJ_SetSequencerRanks\n


### PR DESCRIPTION
[LL][ADC]: fix rank calculation in LL_ADC_INJ_SetSequencerRanks

The `LL_ADC_INJ_SetSequencerRanks` function incorrectly assumed the 
`Rank` argument (e.g., `LL_ADC_INJ_RANK_1`) directly provided the 
numerical rank index for internal calculations. However, these
`LL_ADC_INJ_RANK_x` defines are bit-masked values, not sequential
integers.

This led to miscalculations when determining the bitfield offset within
the `JSQR` register, which relies on a backward calculation based on
sequence length (e.g., `(rank + 3 - length)`).

This patch introduces explicit masking and shifting (using
`__ADC_MASK_SHIFT`) to extract the actual numerical rank index from the 
`Rank` parameter before its use in offset calculations.

The 'tmprank' variable has been repurposed to store the calculated
JSQR bitfield offset.

NOTE: This change is **breaking behavior** for existing code that
incorrectly passed numerical values (1-4) as the `Rank` argument to
`LL_ADC_INJ_SetSequencerRanks`, ignoring its Doxygen documentation. The 
function now strictly expects `LL_ADC_INJ_RANK_x` bitmasks as input.

NOTE: LL_ADC_INJ_GetSequencerRanks returns numerical rank indices
(0-18), not LL_ADC_CHANNEL bitmasks as its Doxygen might suggest. This
behavior aligns with LL_ADC_REG_GetSequencerRanks.
